### PR TITLE
Fix backwards navigation

### DIFF
--- a/webpage/index.html
+++ b/webpage/index.html
@@ -28,7 +28,7 @@
     <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
     <link href="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/css/select2.min.css" rel="stylesheet" />
     <script src="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/js/select2.min.js"></script>
-    
+
     <!-- Custom Sym code/libraries -->
     <!-- Warzone-->
     <script type="text/javascript" src="./pages/warzone/warzone_consts.js"></script>
@@ -86,69 +86,7 @@
             <div class="dropdown">
                 <img src="img/hamburger.png" onclick="myFunction()" class="dropbtn">
                 <div id="myDropdown" class="dropdown-content">
-                    <div class="sym-dropdown-games">   
-                        <div >
-                            <h4>Battlefield 2042</h4>
-                            <div class="sym-dropdown-sub-menu">
-                                <a href="index.html?game=bf2042&page=general-info"><div class=""><img src="./img/symInfoIcon-Lobster.png">General Information</div></a>
-                                <a href="index.html?game=bf2042&page=weapon-mechanics"><div class=""><img src="./img/SymWeaponMechanicsIconAlt.svg">Weapon Mechanics</div></a>
-                                <a href="index.html?game=bf2042&page=charts"><div class=""><img src="./img/symChartIconAlt.png">Weapon Charts</div></a>
-                                <a href="index.html?game=bf2042&page=comparison"><div class=""><img src="./img/symComparisonIconAlt.png">Weapon Comparison</div></a>
-                            </div>
-                        </div>
-                        <div >
-                            <h4>CoD: Warzone</h4>
-                            <div class="sym-dropdown-sub-menu">
-                                <a href="index.html?game=warzone&page=gunsmith"><div class=""><img src="./img/SymWeaponMechanicsIconAlt.svg">Gunsmith</div></a>
-                                <a href="index.html?game=warzone&page=gameplay-mechanics"><div class=""><img src="./img/symInfoIcon-Lobster.png">Gameplay Mechanics</div></a>
-                                <a href="index.html?game=warzone&page=patch-notes"><div class=""><img src="./img/symInfoIcon-Lobster.png">Patch Notes - Sym Style</div></a>
-                            </div>
-                        </div>
-                        <div >
-                            <h4>Battlefield V</h4>
-                            <div class="sym-dropdown-sub-menu">
-                                <a href="index.html?game=bfv&page=general-info"><div class=""><img src="./img/symInfoIcon-Lobster.png">General Information</div></a>
-                                <a href="index.html?game=bfv&page=weapon-mechanics"><div class=""><img src="./img/SymWeaponMechanicsIconAlt.svg">Weapon Mechanics</div></a>
-                                <a href="index.html?game=bfv&page=charts"><div class=""><img src="./img/symChartIconAlt.png">Weapon Charts</div></a>
-                                <a href="index.html?game=bfv&page=comparison"><div class=""><img src="./img/symComparisonIconAlt.png">Weapon Comparison</div></a>
-                            </div>
-                        </div>
-                        <div >
-                            <h4>Battlefield 1</h4>
-                            <div class="sym-dropdown-sub-menu">
-                                <a href="index.html?game=bf1&page=general-info"><div class=""><img src="./img/symInfoIcon-Lobster.png">General Information</div></a>
-                                <a href="index.html?game=bf1&page=weapon-mechanics"><div class=""><img src="./img/SymWeaponMechanicsIconAlt.svg">Weapon Mechanics</div></a>
-                                <a href="index.html?game=bf1&page=charts"><div class=""><img src="./img/symChartIconAlt.png">Weapon Charts</div></a>
-                                <a href="index.html?game=bf1&page=comparison"><div class=""><img src="./img/symComparisonIconAlt.png">Weapon Comparison</div></a>
-                            </div>
-                        </div>
-                        <div >
-                            <h4>Battlefield Hardline</h4>
-                            <div class="sym-dropdown-sub-menu">
-                                <a href="index.html?game=bfh&page=charts"><div class=""><img src="./img/symChartIconAlt.png">Weapon Charts</div></a>
-                                <a href="index.html?game=bfh&page=comparison"><div class=""><img src="./img/symComparisonIconAlt.png">Weapon Comparison</div></a>
-                            </div>
-                        </div>
-                        <div >
-                            <h4>Battlefield 4</h4>
-                            <div class="sym-dropdown-sub-menu">
-                                <a href="index.html?game=bf4&page=general-info"><div class=""><img src="./img/symInfoIcon-Lobster.png">General Information</div></a>
-                                <a href="index.html?game=bf4&page=weapon-mechanics"><div class=""><img src="./img/SymWeaponMechanicsIconAlt.svg">Weapon Mechanics</div></a>
-                                <a href="index.html?game=bf4&page=charts"><div class=""><img src="./img/symChartIconAlt.png">Weapon Charts</div></a>
-                                <a href="index.html?game=bf4&page=comparison"><div class=""><img src="./img/symComparisonIconAlt.png">Weapon Comparison</div></a>
-                            </div>
-                        </div>
-                        <div >
-                            <h4>Battlefield 3</h4>
-                            <div class="sym-dropdown-sub-menu">
-                                <a href="index.html?game=bf3&page=general-info"><div class=""><img src="./img/symInfoIcon-Lobster.png">General Information</div></a>
-                                <a href="index.html?game=bf3&page=weapon-mechanics"><div class=""><img src="./img/SymWeaponMechanicsIconAlt.svg">Weapon Mechanics</div></a>
-                                <a href="index.html?game=bf3&page=charts"><div class=""><img src="./img/symChartIconAlt.png">Weapon Charts</div></a>
-                                <a href="index.html?game=bf3&page=comparison"><div class=""><img src="./img/symComparisonIconAlt.png">Weapon Comparison</div></a>
-                            </div>
-                        </div>
-                        <div style="width:185px"></div>
-                    </div>
+                    <div class="sym-dropdown-games" id="sym-dropdown-games"></div>
                 </div>
               </div>
         </nav>
@@ -168,68 +106,7 @@
             <div class="sym-separator"></div>
             -->
             
-            <div class="sym-games">
-                <div id="bf2042"  class="sym-game">
-                    <div class="sym-game-title">
-                        <img src="img/BF2042_logo.png" />
-                    </div>
-                    <div class="sym-game-datatype"><img src="./img/symInfoIcon-Lobster.png">General Information</div>
-                    <div class="sym-game-datatype"><img src="./img/SymWeaponMechanicsIconAlt.svg">Weapon Mechanics</div>
-                    <div class="sym-game-datatype"><img src="./img/symChartIconAlt.png">Weapon Charts</div>
-                    <div class="sym-game-datatype"><img src="./img/symComparisonIconAlt.png">Weapon Comparison</div>
-                </div>
-                <div id="warzone"  class="sym-game">
-                    <div class="sym-game-title">
-                        <img src="img/CODWZ_logo.png" />
-                    </div>
-                    <div class="sym-game-datatype"><img src="./img/SymWeaponMechanicsIconAlt.svg">Gunsmith</div>
-                    <div class="sym-game-datatype"><img src="./img/symInfoIcon-Lobster.png">Gameplay Mechanics</div>
-                    <div class="sym-game-datatype"><img src="./img/symInfoIcon-Lobster.png">Patch Notes - Sym Style</div>
-                </div>
-                <div id="bfv" class="sym-game">
-                    <div class="sym-game-title">
-                        <img src="img/BFV_logo.png" />
-                    </div>
-                    <div class="sym-game-datatype"><img src="./img/symInfoIcon-Lobster.png">General Information</div>
-                    <div class="sym-game-datatype"><img src="./img/SymWeaponMechanicsIconAlt.svg">Weapon Mechanics</div>
-                    <div class="sym-game-datatype"><img src="./img/symChartIconAlt.png">Weapon Charts</div>
-                    <div class="sym-game-datatype"><img src="./img/symComparisonIconAlt.png">Weapon Comparison</div>
-                </div>
-                <div id="bf1" class="sym-game">
-                    <div class="sym-game-title">
-                        <img src="img/BF1_logo.png" />
-                    </div>
-                    <div class="sym-game-datatype"><img src="./img/symInfoIcon-Lobster.png">General Information</div>
-                    <div class="sym-game-datatype"><img src="./img/SymWeaponMechanicsIconAlt.svg">Weapon Mechanics</div>
-                    <div class="sym-game-datatype"><img src="./img/symChartIconAlt.png">Weapon Charts</div>
-                    <div class="sym-game-datatype"><img src="./img/symComparisonIconAlt.png">Weapon Comparison</div>
-                </div>
-                <div id="bfh" class="sym-game">
-                    <div class="sym-game-title">
-                        <img src="img/BFH_logo.png" />
-                    </div>
-                    <div class="sym-game-datatype"><img src="./img/symChartIconAlt.png">Weapon Charts</div>
-                    <div class="sym-game-datatype"><img src="./img/symComparisonIconAlt.png">Weapon Comparison</div>
-                </div>
-                <div id="bf4" class="sym-game">
-                    <div class="sym-game-title">
-                        <img src="img/BF4_logo.png" />
-                    </div>
-                    <div class="sym-game-datatype"><img src="./img/symInfoIcon-Lobster.png">General Information</div>
-                    <div class="sym-game-datatype"><img src="./img/SymWeaponMechanicsIconAlt.svg">Weapon Mechanics</div>
-                    <div class="sym-game-datatype"><img src="./img/symChartIconAlt.png">Weapon Charts</div>
-                    <div class="sym-game-datatype"><img src="./img/symComparisonIconAlt.png">Weapon Comparison</div>
-                </div>
-                <div id="bf3" class="sym-game">
-                    <div class="sym-game-title">
-                        <img src="img/BF3_logo.png" />
-                    </div>
-                    <div class="sym-game-datatype"><img src="./img/symInfoIcon-Lobster.png">General Information</div>
-                    <div class="sym-game-datatype"><img src="./img/SymWeaponMechanicsIconAlt.svg">Weapon Mechanics</div>
-                    <div class="sym-game-datatype"><img src="./img/symChartIconAlt.png">Weapon Charts</div>
-                    <div class="sym-game-datatype"><img src="./img/symComparisonIconAlt.png">Weapon Comparison</div>
-                </div>
-            </div>
+            <div class="sym-games" id="sym-games"></div>
             
             <div class="sym-separator"></div>
 

--- a/webpage/sym.css
+++ b/webpage/sym.css
@@ -104,6 +104,9 @@
 }
 
 .sym-game-datatype{
+    color: inherit !important;
+    text-decoration: none !important;
+    display: block;
     cursor: pointer;
     padding: 5px 20px 5px 65px;
     font-size: 20px;
@@ -111,7 +114,7 @@
 }
 
 .sym-game-datatype:hover{
-    text-decoration: underline;
+    text-decoration: underline !important;
 }
 
 .sym-game-datatype img{

--- a/webpage/sym.js
+++ b/webpage/sym.js
@@ -101,7 +101,6 @@ window.onload = function () {
         updateQueryString(gameId, "patch-notes")
         break
     }
-    history.go(0)
   })
 }
 
@@ -219,10 +218,10 @@ function loadWarzoneWBStylesheet(){
 }
 
 function generatePath(gameValue, pageValue) {
-  var params = {game: gameValue, 
-    page: pageValue}
-  var queryString = $.param(params)
-  return window.location.pathname + '?' + queryString;
+  return $.param({
+    game: gameValue,
+    page: pageValue
+  });
 }
 
 /*
@@ -230,8 +229,13 @@ function generatePath(gameValue, pageValue) {
   2 or more word values use '-' as in 'weapon-mechanics
 */
 function updateQueryString(gameValue, pageValue){
-  var newURL = window.location.protocol + "//" + window.location.host + generatePath(gameValue, pageValue)
-  window.history.pushState({path:newURL},'',newURL)
+  const params = `?${generatePath(gameValue, pageValue)}`;
+  if (window.location.search === params) {
+    // already have the right parameters, don't need to push a new state
+  } else {
+    // set new parameters and force a refresh
+    window.location.search = params;
+  }
 }
 
 

--- a/webpage/sym.js
+++ b/webpage/sym.js
@@ -10,6 +10,88 @@ const SYM_GITHUB_URL = 'https://github.com/miffyli/sym'
 const SYM_NUM_NEWS_ITEMS = 7
 const NUM_NEWS_ITEMS_SHOWN = 7
 
+const GAMES = {
+  'bf2042': {
+    label: 'Battlefield 2042',
+    shortLabel: 'BF2042',
+    logo: 'img/BF2042_logo.png',
+    pages: ['general-info', 'weapon-mechanics', 'charts', 'comparison']
+  },
+  'warzone': {
+    label: 'CoD: Warzone',
+    shortLabel: 'Warzone',
+    logo: 'img/CODWZ_logo.png',
+    pages: ['gunsmith', 'gameplay-mechanics', 'patch-notes']
+  },
+  'bfv': {
+    label: 'Battlefield V',
+    shortLabel: 'BFV',
+    logo: 'img/BFV_logo.png',
+    pages: ['general-info', 'weapon-mechanics', 'charts', 'comparison']
+  },
+  'bf1': {
+    label: 'Battlefield 1',
+    shortLabel: 'BF1',
+    logo: 'img/BF1_logo.png',
+    pages: ['general-info', 'weapon-mechanics', 'charts', 'comparison']
+  },
+  'bfh': {
+    label: 'Battlefield Hardline',
+    shortLabel: 'BFH',
+    logo: 'img/BFH_logo.png',
+    pages: ['charts', 'comparison']
+  },
+  'bf4': {
+    label: 'Battlefield 4',
+    shortLabel: 'BF4',
+    logo: 'img/BF4_logo.png',
+    pages: ['general-info', 'weapon-mechanics', 'charts', 'comparison']
+  },
+  'bf3': {
+    label: 'Battlefield 3',
+    shortLabel: 'BF3',
+    logo: 'img/BF3_logo.png',
+    pages: ['general-info', 'weapon-mechanics', 'charts', 'comparison']
+  }
+};
+
+const PAGE_TYPES = {
+  'general-info': {
+    label: 'General Information',
+    img: './img/symInfoIcon-Lobster.png'
+  },
+  'weapon-mechanics': {
+    label: 'Weapon Mechanics',
+    img: './img/SymWeaponMechanicsIconAlt.svg'
+  },
+  'charts': {
+    label: 'Weapon Charts',
+    img: './img/symChartIconAlt.png'
+  },
+  'comparison': {
+    label: 'Weapon Comparison',
+    img: './img/symComparisonIconAlt.png'
+  },
+  'equipment': {
+    label: 'Equipment Data',
+    img: ''
+  },
+  'gunsmith': {
+    label: 'Gunsmith',
+    img: './img/SymWeaponMechanicsIconAlt.svg'
+  },
+  'gameplay-mechanics': {
+    label: 'Gameplay Mechanics',
+    img: './img/symInfoIcon-Lobster.png'
+  },
+  'patch-notes': {
+    label: 'Patch Notes - Sym Style',
+    img: './img/symInfoIcon-Lobster.png'
+  }
+};
+
+
+
 /*
     This code runs after the page loads all resources.
     Used to set up events and widgets and any other code that needs
@@ -70,41 +152,64 @@ window.onload = function () {
   $.each([bannerRoute, jumpInRoute, learnMoreRoute], (idx, selector) => {
     linkAnchor($(selector), selector)
   })
-  
-  $('.sym-game-datatype').click(function () {
-    var clicked = $(this).text();
-    var gameId = $(this).parent().attr('id')
-  
-    switch(clicked){
-      case 'General Information':
-        updateQueryString(gameId, "general-info")
-        break
-      case 'Weapon Mechanics':
-        updateQueryString(gameId, "weapon-mechanics")
-        break
-      case 'Weapon Charts':
-        updateQueryString(gameId, "charts")
-        break
-      case 'Weapon Comparison':
-        updateQueryString(gameId, "comparison")
-        break
-      case 'Equipment Data':
-        updateQueryString(gameId, "equipment")
-        break
-      case 'Gunsmith':
-        updateQueryString(gameId, "gunsmith")
-        break
-      case 'Gameplay Mechanics':
-        updateQueryString(gameId, "gameplay-mechanics")
-        break
-      case 'Patch Notes - Sym Style':
-        updateQueryString(gameId, "patch-notes")
-        break
-    }
-  })
+
+  setupDropdownLinks();
+  setupGameLinks();
 }
 
 
+
+const gamePageRef = (gameId, pageName) => `index.html?game=${gameId}&page=${pageName}`;
+
+const append = (parent, type) => {
+  return parent.appendChild(document.createElement(type));
+}
+
+const setupDropdownLinks = () => {
+  const rootNode = document.getElementById('sym-dropdown-games');
+  if (rootNode === null) return;
+  for (const [gameId, game] of Object.entries(GAMES)) {
+    const gameDiv = append(rootNode, 'div');
+    const gameTitle = append(gameDiv, 'h4');
+    gameTitle.textContent = game.label;
+    const linkHolder = append(gameDiv, 'div');
+    linkHolder.className = 'sym-dropdown-sub-menu';
+    for (const page of game.pages) {
+      const pageData = PAGE_TYPES[page];
+      const linkNode = append(linkHolder, 'a');
+      linkNode.href = gamePageRef(gameId, page);
+      const labelNode = append(linkNode, 'div');
+      const img = append(labelNode, 'img');
+      img.src = pageData.img;
+      labelNode.append(pageData.label);
+    }
+  }
+  let widthDiv = append(rootNode, 'div');
+  widthDiv.style.width = '185px';
+};
+
+const setupGameLinks = () => {
+  const rootNode = document.getElementById('sym-games');
+  if (rootNode === null) return;
+  for (const [gameId, game] of Object.entries(GAMES)) {
+    const gameNode = append(rootNode, 'div');
+    gameNode.id = gameId;
+    gameNode.className = 'sym-game';
+    const titleNode = append(gameNode, 'div');
+    titleNode.className = 'sym-game-title';
+    const titleImgNode = append(titleNode, 'img');
+    titleImgNode.src = game.logo;
+    for (let page of game.pages) {
+      const pageData = PAGE_TYPES[page];
+      const linkNode = append(gameNode, 'a');
+      linkNode.className = 'sym-game-datatype';
+      linkNode.href = gamePageRef(gameId, page);
+      const linkImgNode = append(linkNode, 'img');
+      linkImgNode.src = pageData.img;
+      linkNode.append(pageData.label);
+    }
+  }
+};
 
 /*
   Load given page file with header, and finish
@@ -218,10 +323,11 @@ function loadWarzoneWBStylesheet(){
 }
 
 function generatePath(gameValue, pageValue) {
-  return $.param({
+  const params = $.param({
     game: gameValue,
     page: pageValue
   });
+  return `?${params}`;
 }
 
 /*
@@ -229,7 +335,7 @@ function generatePath(gameValue, pageValue) {
   2 or more word values use '-' as in 'weapon-mechanics
 */
 function updateQueryString(gameValue, pageValue){
-  const params = `?${generatePath(gameValue, pageValue)}`;
+  const params = generatePath(gameValue, pageValue);
   if (window.location.search === params) {
     // already have the right parameters, don't need to push a new state
   } else {
@@ -266,21 +372,17 @@ function exceuteQueryStringParams(){
             break
         }
         break
+      case 'bfh':
+      case 'bf3':
+      case 'bf4':
       case 'bf2042':
-        switch(page){
-          case 'general-info':
-            openOtherTitlesSelectionPageFromQueryString('BF2042 General Information')
-            break
-          case 'weapon-mechanics':
-            openOtherTitlesSelectionPageFromQueryString('BF2042 Weapon Mechanics')
-            break
-          case 'charts':
-            openOtherTitlesSelectionPageFromQueryString('BF2042 Weapon Charts')
-            break
-          case 'comparison':
-            openOtherTitlesSelectionPageFromQueryString('BF2042 Comparison')
-            break
+        const gameData = GAMES[game];
+        const pageData = PAGE_TYPES[page];
+        let pageLabel = pageData.label;
+        if (pageLabel === 'Weapon Comparison') {
+          pageLabel = 'Comparison';
         }
+        openOtherTitlesSelectionPageFromQueryString(`${gameData.shortLabel} ${pageLabel}`)
         break
       case 'bfv':
         switch(page){
@@ -324,48 +426,6 @@ function exceuteQueryStringParams(){
             break
           case 'weapon-mechanics':
             openBF1SelectionPageFromQueryString('Weapon Mechanics')
-            break
-        }
-        break
-      case 'bfh':
-        switch(page){
-          case 'comparison':
-            openOtherTitlesSelectionPageFromQueryString('BFH Comparison')
-            break
-          case 'charts':
-            openOtherTitlesSelectionPageFromQueryString('BFH Weapon Charts')
-            break
-        }
-        break
-      case 'bf4':
-        switch(page){
-          case 'general-info':
-            openOtherTitlesSelectionPageFromQueryString('BF4 General Info')
-            break
-          case 'comparison':
-            openOtherTitlesSelectionPageFromQueryString('BF4 Comparison')
-            break
-          case 'charts':
-            openOtherTitlesSelectionPageFromQueryString('BF4 Weapon Charts')
-            break
-          case 'weapon-mechanics':
-            openOtherTitlesSelectionPageFromQueryString('BF4 Weapon Mechanics')
-            break
-        }
-        break
-      case 'bf3':
-        switch(page){
-          case 'general-info':
-            openOtherTitlesSelectionPageFromQueryString('BF3 General Info')
-            break
-          case 'comparison':
-            openOtherTitlesSelectionPageFromQueryString('BF3 Comparison')
-            break
-          case 'charts':
-            openOtherTitlesSelectionPageFromQueryString('BF3 Weapon Charts')
-            break
-          case 'weapon-mechanics':
-            openOtherTitlesSelectionPageFromQueryString('BF3 Weapon Mechanics')
             break
         }
         break
@@ -433,6 +493,9 @@ function exceuteQueryStringParams(){
             loadPageWithHeader('./pages/misc/partners.html', 'Our Partners')
             updateQueryString("sym", "partners")
             break
+          case 'home':
+            $(".sym-main-content-home").show();
+            break;
         }
         break
       default:


### PR DESCRIPTION
~~Update search params in window location directly, instead of pushing state and forcing a refresh. This makes forward/backward behavior work for me.~~


2nd commit:

Started looking at getting right-click open in new tab working after the initial commit. Figured it would be easier to just change the divs to anchor tags. After doing that I noticed that the game specific links are setup in two places (the main page content, and the dropdown menu). So to reduce the number of places that information is repeated I pulled all the game specific data into two objects (GAMES, PAGE_TYPES), and added functions to create the DOM elements for both the dropdown menu and main page links.


* `sym-game-datatype` links are now anchor tags
* Game specific links are now specified once in javascript rather than once in HTML (dropdown menu) and again in JS (main page links).
* Added a case statement for game=sym, page=home.
  * Before this change right clicking the site banner and opening in a new tab would result in a mostly blank page.

---

I'm just interested in getting forward/backward navigation and right-click link functionality working, so if the reformatting is too extreme I'm happy to make a new commit with fewer changes.
